### PR TITLE
feat: Enhance phonetics practice mode UI and stability

### DIFF
--- a/app/src/main/java/com/example/readingfoundations/ui/screens/phonetics/PhoneticsScreen.kt
+++ b/app/src/main/java/com/example/readingfoundations/ui/screens/phonetics/PhoneticsScreen.kt
@@ -53,7 +53,7 @@ fun PhoneticsScreen(
                 title = { Text(stringResource(R.string.phonetics_practice)) },
                 navigationIcon = {
                     IconButton(onClick = { navController.navigateUp() }) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.back_button_desc))
                     }
                 },
                 actions = {
@@ -66,7 +66,7 @@ fun PhoneticsScreen(
                     }) {
                         Icon(
                             imageVector = if (uiState.inPracticeMode) Icons.Default.Stop else Icons.Default.PlayArrow,
-                            contentDescription = if (uiState.inPracticeMode) "Stop Practice" else "Start Practice"
+                            contentDescription = if (uiState.inPracticeMode) stringResource(R.string.stop_practice_desc) else stringResource(R.string.start_practice_desc)
                         )
                     }
                 }
@@ -138,10 +138,10 @@ fun PracticeContent(
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             items(uiState.options) { option ->
-                val color = when (uiState.isCorrect) {
-                    true -> if (option == uiState.targetLetter) Color.Green else Color.Unspecified
-                    false -> if (option == uiState.selectedLetter) Color.Red else Color.Unspecified
-                    null -> Color.Unspecified
+                val color = when {
+                    uiState.isCorrect == true && option == uiState.targetLetter -> Color.Green
+                    uiState.isCorrect == false && option == uiState.selectedLetter -> MaterialTheme.colorScheme.error
+                    else -> Color.Unspecified
                 }
                 PracticeLetterCard(
                     letter = option,
@@ -196,7 +196,7 @@ fun PracticeLetterCard(
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(color),
+                .background(color, shape = CardDefaults.shape),
             contentAlignment = Alignment.Center
         ) {
             Text(

--- a/app/src/main/java/com/example/readingfoundations/ui/screens/phonetics/PhoneticsViewModel.kt
+++ b/app/src/main/java/com/example/readingfoundations/ui/screens/phonetics/PhoneticsViewModel.kt
@@ -2,6 +2,7 @@ package com.example.readingfoundations.ui.screens.phonetics
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -15,6 +16,7 @@ class PhoneticsViewModel : ViewModel() {
     val uiState: StateFlow<PhoneticsUiState> = _uiState.asStateFlow()
 
     val alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".map { it.toString() }
+    private var practiceJob: Job? = null
 
     fun onLetterSelected(letter: String) {
         _uiState.update { it.copy(selectedLetter = letter) }
@@ -26,14 +28,15 @@ class PhoneticsViewModel : ViewModel() {
     }
 
     fun stopPractice() {
+        practiceJob?.cancel()
         _uiState.value = PhoneticsUiState()
     }
 
     fun checkAnswer(selectedOption: String) {
         val isCorrect = selectedOption == _uiState.value.targetLetter
-        _uiState.update { it.copy(isCorrect = isCorrect) }
+        _uiState.update { it.copy(isCorrect = isCorrect, selectedLetter = selectedOption) }
 
-        viewModelScope.launch {
+        practiceJob = viewModelScope.launch {
             delay(1000) // wait for 1 second
             if (isCorrect) {
                 generateNewQuestion()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,7 @@
     <string name="congratulations">Congratulations!</string>
     <string name="level_complete">You have completed level %1$d.</string>
     <string name="continue_button">Continue</string>
+    <string name="back_button_desc">Back</string>
+    <string name="stop_practice_desc">Stop Practice</string>
+    <string name="start_practice_desc">Start Practice</string>
 </resources>


### PR DESCRIPTION
This commit introduces several improvements to the phonetics practice mode:

-   **Cancels Practice Job:** In `PhoneticsViewModel.kt`, the ongoing practice job is now cancelled when the practice is stopped. This prevents potential memory leaks or unexpected behavior from coroutines that continue to run after the user has exited the practice session.
-   **Highlights Selected Answer:** The UI has been updated to provide better feedback. Now, when a user selects an incorrect answer, it is highlighted in red, making it clear which option they chose.
-   **UI Refinements:**
    -   The background color of the practice letter cards now respects the card's shape for a cleaner look.
    -   Content descriptions for the back, start practice, and stop practice buttons have been extracted into `strings.xml` for better accessibility and localization.