### PR TITLE
Feat: Add progress tracking and level selection

### DIFF
--- a/app/src/main/java/com/example/readingfoundations/data/local/Converters.kt
+++ b/app/src/main/java/com/example/readingfoundations/data/local/Converters.kt
@@ -6,18 +6,26 @@ import com.google.gson.reflect.TypeToken
 
 class Converters {
     private val gson = Gson()
-    private val type = object : TypeToken<List<String>>() {}.type
+    private val listStringType = object : TypeToken<List<String>>() {}.type
+    private val mapIntIntType = object : TypeToken<Map<Int, Int>>() {}.type
+
     @TypeConverter
     fun fromString(value: String?): List<String>? {
-        return value?.let { gson.fromJson(it, type) }
-    }
-    @TypeConverter
-    fun fromList(list: List<String>?): String? {
-        return list?.let { gson.toJson(it, type) }
+        return value?.let { gson.fromJson(it, listStringType) }
     }
 
-    companion object {
-        private val gson = Gson()
-        private val type = object : TypeToken<List<String>>() {}.type
+    @TypeConverter
+    fun fromList(list: List<String>?): String? {
+        return list?.let { gson.toJson(it, listStringType) }
+    }
+
+    @TypeConverter
+    fun fromStringMap(value: String?): Map<Int, Int>? {
+        return value?.let { gson.fromJson(it, mapIntIntType) }
+    }
+
+    @TypeConverter
+    fun fromMap(map: Map<Int, Int>?): String? {
+        return map?.let { gson.toJson(it, mapIntIntType) }
     }
 }

--- a/app/src/main/java/com/example/readingfoundations/data/models/UserProgress.kt
+++ b/app/src/main/java/com/example/readingfoundations/data/models/UserProgress.kt
@@ -6,6 +6,8 @@ import androidx.room.PrimaryKey
 @Entity(tableName = "user_progress")
 data class UserProgress(
     @PrimaryKey val id: Int = 1, // Singleton entry
-    val lastWordLevelCompleted: Int = 0,
-    val lastSentenceLevelCompleted: Int = 0
+    val wordLevelsProgress: Map<Int, Int> = emptyMap(),
+    val sentenceLevelsProgress: Map<Int, Int> = emptyMap(),
+    val currentWordLevelInProgress: Int = 0,
+    val currentSentenceLevelInProgress: Int = 0
 )

--- a/app/src/main/java/com/example/readingfoundations/ui/AppViewModelProvider.kt
+++ b/app/src/main/java/com/example/readingfoundations/ui/AppViewModelProvider.kt
@@ -1,18 +1,25 @@
 package com.example.readingfoundations.ui
 
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.example.readingfoundations.ReadingFoundationsApp
+import com.example.readingfoundations.ui.screens.home.HomeViewModel
 import com.example.readingfoundations.ui.screens.phonetics.PhoneticsViewModel
-import com.example.readingfoundations.ui.screens.reading_sentence.SentenceReadingViewModel
 import com.example.readingfoundations.ui.screens.punctuation.PunctuationViewModel
+import com.example.readingfoundations.ui.screens.reading_sentence.SentenceReadingViewModel
 import com.example.readingfoundations.ui.screens.reading_word.WordReadingViewModel
 import com.example.readingfoundations.ui.screens.settings.SettingsViewModel
 
 object AppViewModelProvider {
     val Factory = viewModelFactory {
+        initializer {
+            HomeViewModel(
+                readingFoundationsApplication().container.appRepository
+            )
+        }
         initializer {
             PhoneticsViewModel()
         }
@@ -22,13 +29,17 @@ object AppViewModelProvider {
             )
         }
         initializer {
+            val savedStateHandle = createSavedStateHandle()
             WordReadingViewModel(
-                readingFoundationsApplication().container.appRepository
+                readingFoundationsApplication().container.appRepository,
+                savedStateHandle
             )
         }
         initializer {
+            val savedStateHandle = createSavedStateHandle()
             SentenceReadingViewModel(
-                readingFoundationsApplication().container.appRepository
+                readingFoundationsApplication().container.appRepository,
+                savedStateHandle
             )
         }
         initializer {

--- a/app/src/main/java/com/example/readingfoundations/ui/screens/AppNavigation.kt
+++ b/app/src/main/java/com/example/readingfoundations/ui/screens/AppNavigation.kt
@@ -21,16 +21,37 @@ fun AppNavigation() {
     NavHost(navController = navController, startDestination = "home") {
         composable("home") { HomeScreen(navController) }
         composable("phonetics") { PhoneticsScreen(navController) }
-        composable("word_building") { WordReadingScreen(navController) }
-        composable("sentence_reading") { SentenceReadingScreen(navController) }
+        composable(
+            "word_building/{level}",
+            arguments = listOf(navArgument("level") { type = NavType.IntType })
+        ) {
+            WordReadingScreen(navController)
+        }
+        composable(
+            "sentence_reading/{level}",
+            arguments = listOf(navArgument("level") { type = NavType.IntType })
+        ) {
+            SentenceReadingScreen(navController)
+        }
         composable("punctuation") { PunctuationPracticeScreen(navController) }
         composable("settings") { SettingsScreen(navController) }
         composable(
-            "level_complete/{level}",
-            arguments = listOf(navArgument("level") { type = NavType.IntType })
+            "level_complete/{level}/{score}/{totalQuestions}",
+            arguments = listOf(
+                navArgument("level") { type = NavType.IntType },
+                navArgument("score") { type = NavType.IntType },
+                navArgument("totalQuestions") { type = NavType.IntType }
+            )
         ) { backStackEntry ->
             val level = backStackEntry.arguments?.getInt("level") ?: 0
-            LevelCompleteScreen(navController = navController, level = level)
+            val score = backStackEntry.arguments?.getInt("score") ?: 0
+            val totalQuestions = backStackEntry.arguments?.getInt("totalQuestions") ?: 0
+            LevelCompleteScreen(
+                navController = navController,
+                level = level,
+                score = score,
+                totalQuestions = totalQuestions
+            )
         }
         composable(
             "quiz_complete/{score}/{totalQuestions}",

--- a/app/src/main/java/com/example/readingfoundations/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/readingfoundations/ui/screens/home/HomeScreen.kt
@@ -1,106 +1,177 @@
 package com.example.readingfoundations.ui.screens.home
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ChromeReaderMode
-import androidx.compose.material.icons.filled.Construction
-import androidx.compose.material.icons.filled.EditNote
-import androidx.compose.material.icons.filled.RecordVoiceOver
-import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material3.Card
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.example.readingfoundations.R
+import com.example.readingfoundations.ui.AppViewModelProvider
 
 private data class MenuItem(
-    val route: String, val title: Int, val icon: ImageVector
+    val id: String, val title: Int, val icon: ImageVector, val route: String
 )
 
-private val menuItems = listOf(
-    MenuItem("phonetics", R.string.phonetics, Icons.Default.RecordVoiceOver),
-    MenuItem("word_building", R.string.word_building, Icons.Default.Construction),
-    MenuItem(
-        "sentence_reading", R.string.sentence_reading, Icons.AutoMirrored.Filled.ChromeReaderMode
-    ),
-    MenuItem("punctuation", R.string.punctuation, Icons.Default.EditNote),
-    MenuItem("settings", R.string.settings, Icons.Default.Settings)
+private val staticMenuItems = listOf(
+    MenuItem("phonetics", R.string.phonetics, Icons.Default.RecordVoiceOver, "phonetics"),
+    MenuItem("punctuation", R.string.punctuation, Icons.Default.EditNote, "punctuation"),
+    MenuItem("settings", R.string.settings, Icons.Default.Settings, "settings")
 )
 
 @Composable
-fun HomeScreen(navController: NavController) {
-    Column(
+fun HomeScreen(
+    navController: NavController,
+    viewModel: HomeViewModel = viewModel(factory = AppViewModelProvider.Factory)
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    LazyColumn(
         modifier = Modifier
             .fillMaxSize()
             .padding(horizontal = 16.dp)
             .statusBarsPadding(),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(24.dp)
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        contentPadding = PaddingValues(bottom = 16.dp)
     ) {
-        EditorialMoment(
-            onStartLearningClick = { navController.navigate(menuItems.filter { it.route != "settings" }.random().route) },
-        )
-        LazyVerticalGrid(
-            columns = GridCells.Fixed(2),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
-            contentPadding = PaddingValues(vertical = 16.dp)
-        ) {
-            items(menuItems) { item ->
-                MenuItemCard(item = item, onClick = { navController.navigate(item.route) })
+        item {
+            EditorialMoment(
+                onStartLearningClick = { navController.navigate("word_building/1") },
+            )
+        }
+
+        item {
+            LevelSelection(
+                title = stringResource(R.string.word_building),
+                icon = Icons.Default.Construction,
+                numLevels = 5, // As per memory
+                progressMap = uiState.userProgress.wordLevelsProgress,
+                onLevelClick = { level -> navController.navigate("word_building/$level") }
+            )
+        }
+
+        item {
+            LevelSelection(
+                title = stringResource(R.string.sentence_reading),
+                icon = Icons.AutoMirrored.Filled.ChromeReaderMode,
+                numLevels = 14, // As per memory
+                progressMap = uiState.userProgress.sentenceLevelsProgress,
+                onLevelClick = { level -> navController.navigate("sentence_reading/$level") }
+            )
+        }
+
+        items(staticMenuItems.size) { index ->
+            val item = staticMenuItems[index]
+            StaticMenuItemCard(
+                item = item,
+                onClick = { navController.navigate(item.route) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun LevelSelection(
+    title: String,
+    icon: ImageVector,
+    numLevels: Int,
+    progressMap: Map<Int, Int>,
+    onLevelClick: (Int) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        onClick = { expanded = !expanded }
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Icon(imageVector = icon, contentDescription = null, modifier = Modifier.size(40.dp))
+                Text(text = title, style = MaterialTheme.typography.titleLarge)
+                Spacer(modifier = Modifier.weight(1f))
+                Icon(
+                    imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                    contentDescription = null
+                )
+            }
+            AnimatedVisibility(visible = expanded) {
+                LazyVerticalGrid(
+                    columns = GridCells.Adaptive(minSize = 64.dp),
+                    contentPadding = PaddingValues(top = 16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.heightIn(max = 300.dp) // Avoid excessive height
+                ) {
+                    items(numLevels) { level ->
+                        val levelNum = level + 1
+                        val progress = progressMap[levelNum] ?: 0
+                        LevelCard(
+                            level = levelNum,
+                            progress = progress,
+                            onClick = { onLevelClick(levelNum) }
+                        )
+                    }
+                }
             }
         }
     }
 }
 
 @Composable
-private fun MenuItemCard(
+private fun LevelCard(level: Int, progress: Int, onClick: () -> Unit) {
+    Card(
+        modifier = Modifier.aspectRatio(1f),
+        onClick = onClick
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            CircularProgressIndicator(
+                progress = { progress / 100f },
+                modifier = Modifier.fillMaxSize(0.8f),
+                strokeWidth = 4.dp
+            )
+            Text(
+                text = level.toString(),
+                style = MaterialTheme.typography.titleLarge,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+@Composable
+private fun StaticMenuItemCard(
     item: MenuItem, onClick: () -> Unit
 ) {
     Card(
         modifier = Modifier
-            .aspectRatio(1f)
+            .fillMaxWidth()
             .clickable(onClick = onClick)
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(16.dp),
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            Icon(
-                imageVector = item.icon,
-                contentDescription = stringResource(item.title),
-                modifier = Modifier.size(48.dp)
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = stringResource(item.title),
-                textAlign = TextAlign.Center,
-                style = MaterialTheme.typography.titleMedium
-            )
+            Icon(imageVector = item.icon, contentDescription = null, modifier = Modifier.size(40.dp))
+            Text(text = stringResource(item.title), style = MaterialTheme.typography.titleLarge)
         }
     }
 }

--- a/app/src/main/java/com/example/readingfoundations/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/readingfoundations/ui/screens/home/HomeViewModel.kt
@@ -1,0 +1,27 @@
+package com.example.readingfoundations.ui.screens.home
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.readingfoundations.data.AppRepository
+import com.example.readingfoundations.data.models.UserProgress
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+class HomeViewModel(appRepository: AppRepository) : ViewModel() {
+
+    val uiState: StateFlow<HomeUiState> =
+        appRepository.getUserProgress()
+            .map { it ?: UserProgress() }
+            .map { HomeUiState(it) }
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5_000),
+                initialValue = HomeUiState()
+            )
+}
+
+data class HomeUiState(
+    val userProgress: UserProgress = UserProgress()
+)

--- a/app/src/main/java/com/example/readingfoundations/ui/screens/reading_sentence/SentenceReadingScreen.kt
+++ b/app/src/main/java/com/example/readingfoundations/ui/screens/reading_sentence/SentenceReadingScreen.kt
@@ -11,12 +11,17 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.example.readingfoundations.data.models.Sentence
 import com.example.readingfoundations.ui.AppViewModelProvider
 import com.example.readingfoundations.utils.TextToSpeechManager
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -24,9 +29,26 @@ fun SentenceReadingScreen(
     navController: NavController,
     viewModel: SentenceReadingViewModel = viewModel(factory = AppViewModelProvider.Factory)
 ) {
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val ttsManager = remember { TextToSpeechManager(context) }
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    LaunchedEffect(viewModel.navigationEvent, lifecycleOwner) {
+        lifecycleOwner.lifecycleScope.launch {
+            lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.navigationEvent.collect { event ->
+                    when (event) {
+                        is NavigationEvent.LevelComplete -> {
+                            navController.navigate("level_complete/${event.level}/${event.score}/${event.totalQuestions}") {
+                                popUpTo("home")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     DisposableEffect(Unit) {
         onDispose {
@@ -53,13 +75,33 @@ fun SentenceReadingScreen(
                 .padding(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            if (uiState.isPracticeMode && uiState.quizState != null) {
-                PracticeMode(
-                    quizState = uiState.quizState!!,
-                    onAnswerSubmitted = { answer -> viewModel.submitAnswer(answer) },
-                    onNextClicked = { viewModel.nextQuestion() },
-                    onSpeakClicked = { text -> ttsManager.speak(text) }
-                )
+            if (uiState.sentences.isEmpty()) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            } else if (uiState.isPracticeMode && uiState.quizState != null) {
+                val quizState = uiState.quizState!!
+                val progress = (quizState.currentQuestionIndex.toFloat()) / quizState.questions.size
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    LinearProgressIndicator(
+                        progress = { progress },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(8.dp)
+                    )
+                    Text(
+                        text = "Sentence ${quizState.currentQuestionIndex + 1} of ${quizState.questions.size}",
+                        style = MaterialTheme.typography.labelMedium,
+                        modifier = Modifier.padding(top = 4.dp)
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    PracticeMode(
+                        quizState = quizState,
+                        onAnswerSubmitted = { answer -> viewModel.submitAnswer(answer) },
+                        onNextClicked = { viewModel.nextQuestion() },
+                        onSpeakClicked = { text -> ttsManager.speak(text) }
+                    )
+                }
             } else {
                 LearnMode(
                     sentences = uiState.sentences,
@@ -77,7 +119,10 @@ fun LearnMode(
     onSentenceClicked: (String) -> Unit,
     onStartPracticeClicked: () -> Unit
 ) {
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
         Text("Learn these sentences:", style = MaterialTheme.typography.headlineMedium)
         Spacer(modifier = Modifier.height(16.dp))
         LazyColumn(
@@ -100,7 +145,11 @@ fun LearnMode(
             }
         }
         Spacer(modifier = Modifier.height(16.dp))
-        Button(onClick = onStartPracticeClicked, enabled = sentences.isNotEmpty()) {
+        Button(
+            onClick = onStartPracticeClicked,
+            enabled = sentences.isNotEmpty(),
+            modifier = Modifier.fillMaxWidth(0.5f)
+        ) {
             Text("Start Practice")
         }
     }
@@ -120,86 +169,95 @@ fun PracticeMode(
     val remainingWords = remember(currentQuestion) { mutableStateListOf(*jumbledWords.toTypedArray()) }
 
 
-    Text("Unscramble the sentence:", style = MaterialTheme.typography.headlineMedium)
-    Spacer(modifier = Modifier.height(16.dp))
-
-    Button(onClick = { onSpeakClicked(currentQuestion.text) }) {
-        Text("Hear the sentence")
-    }
-    Spacer(modifier = Modifier.height(16.dp))
-
-    // Assembled sentence display
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .defaultMinSize(minHeight = 100.dp),
-        elevation = CardDefaults.cardElevation(4.dp)
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        Text("Unscramble the sentence:", style = MaterialTheme.typography.headlineMedium)
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Button(onClick = { onSpeakClicked(currentQuestion.text) }) {
+            Text("Hear the sentence")
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Assembled sentence display
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .defaultMinSize(minHeight = 100.dp),
+            elevation = CardDefaults.cardElevation(4.dp)
+        ) {
+            FlowRow(
+                modifier = Modifier
+                    .padding(16.dp)
+                    .fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                assembledWords.forEachIndexed { index, word ->
+                    Button(
+                        onClick = {
+                            remainingWords.add(word)
+                            assembledWords.removeAt(index)
+                        },
+                        colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.secondary)
+                    ) {
+                        Text(word)
+                    }
+                }
+            }
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Jumbled words bank
         FlowRow(
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            assembledWords.forEachIndexed { index, word ->
-                Button(
-                    onClick = {
-                        remainingWords.add(word)
-                        assembledWords.removeAt(index)
-                    },
-                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.secondary)
-                ) {
+            remainingWords.forEachIndexed { index, word ->
+                Button(onClick = {
+                    assembledWords.add(word)
+                    remainingWords.removeAt(index)
+                }) {
                     Text(word)
                 }
             }
         }
-    }
-    Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.weight(1f))
 
-    // Jumbled words bank
-    FlowRow(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        remainingWords.forEachIndexed { index, word ->
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            Button(
+                onClick = { onAnswerSubmitted(assembledWords.joinToString(" ")) },
+                enabled = quizState.isAnswerCorrect == null && remainingWords.isEmpty()
+            ) {
+                Text("Submit")
+            }
+            Spacer(Modifier.width(8.dp))
             Button(onClick = {
-                assembledWords.add(word)
-                remainingWords.removeAt(index)
+                assembledWords.clear()
+                remainingWords.clear()
+                remainingWords.addAll(jumbledWords)
             }) {
-                Text(word)
+                Text("Reset")
             }
         }
-    }
-    Spacer(modifier = Modifier.height(24.dp))
 
-    Row {
-        Button(
-            onClick = { onAnswerSubmitted(assembledWords.joinToString(" ")) },
-            enabled = quizState.isAnswerCorrect == null && remainingWords.isEmpty()
-        ) {
-            Text("Submit")
-        }
-        Spacer(Modifier.width(8.dp))
-        Button(onClick = {
-            assembledWords.clear()
-            remainingWords.clear()
-            remainingWords.addAll(jumbledWords)
-        }) {
-            Text("Reset")
-        }
-    }
-
-
-    quizState.isAnswerCorrect?.let { isCorrect ->
-        Text(
-            text = if (isCorrect) "Correct!" else "Incorrect. Try again!",
-            color = if (isCorrect) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error,
-            style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.padding(top = 16.dp)
-        )
-        if (isCorrect) {
-            Button(onClick = onNextClicked, modifier = Modifier.padding(top = 8.dp)) {
-                Text("Next Sentence")
+        quizState.isAnswerCorrect?.let { isCorrect ->
+            Text(
+                text = if (isCorrect) "Correct!" else "Incorrect. Try again!",
+                color = if (isCorrect) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier.padding(top = 16.dp)
+            )
+            if (isCorrect) {
+                Button(onClick = onNextClicked, modifier = Modifier.padding(top = 8.dp)) {
+                    Text("Next Sentence")
+                }
             }
         }
     }


### PR DESCRIPTION
This commit introduces a new progress tracking system and a redesigned home screen that allows users to view and replay levels.

Key changes:
- Updated the `UserProgress` data model to store per-level progress for "Word Building" and "Sentence Reading" categories.
- Redesigned the home screen to display expandable level selection grids with progress bars for each level.
- Added in-lesson progress bars to the word and sentence reading screens to show quiz progress.
- Updated ViewModels to handle the new progress tracking logic and level selection.