### PR TITLE
feat: Add progress bar to punctuation practice

### DIFF
--- a/app/src/main/java/com/example/readingfoundations/ui/screens/punctuation/PunctuationPracticeScreen.kt
+++ b/app/src/main/java/com/example/readingfoundations/ui/screens/punctuation/PunctuationPracticeScreen.kt
@@ -52,10 +52,21 @@ fun PunctuationPracticeScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(paddingValues)
-                .padding(16.dp),
+                .padding(paddingValues),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
+            if (uiState.progress > 0) {
+                LinearProgressIndicator(
+                    progress = { uiState.progress },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
             if (uiState.questions.isEmpty()) {
                 Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                     CircularWavyProgressIndicator()
@@ -66,6 +77,7 @@ fun PunctuationPracticeScreen(
                     onAnswerSelected = { answer -> viewModel.submitAnswer(answer) },
                     onNextClicked = { viewModel.nextQuestion() }
                 )
+            }
             }
         }
     }


### PR DESCRIPTION
This commit introduces a linear progress bar to the punctuation practice screen to provide users with visual feedback on their quiz progress.

The changes include:
- Updating `PunctuationUiState` to hold a `progress` value.
- Modifying `PunctuationViewModel` to calculate and update the progress as the user advances through the questions.
- Adding a `LinearProgressIndicator` to the `PunctuationPracticeScreen`, bound to the new progress state.