### PR TITLE
feat: Update progress bar to advance on correct answer

### DIFF
--- a/app/src/main/java/com/example/readingfoundations/ui/screens/punctuation/PunctuationPracticeScreen.kt
+++ b/app/src/main/java/com/example/readingfoundations/ui/screens/punctuation/PunctuationPracticeScreen.kt
@@ -84,6 +84,11 @@ fun PunctuationQuestionCard(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        LinearProgressIndicator(
+            progress = { uiState.progress },
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.height(16.dp))
         Text(
             text = "Question ${uiState.currentQuestionIndex + 1} of ${uiState.questions.size}",
             style = MaterialTheme.typography.titleMedium

--- a/app/src/main/java/com/example/readingfoundations/ui/screens/punctuation/PunctuationViewModel.kt
+++ b/app/src/main/java/com/example/readingfoundations/ui/screens/punctuation/PunctuationViewModel.kt
@@ -35,11 +35,18 @@ class PunctuationViewModel(private val appRepository: AppRepository) : ViewModel
         val currentState = _uiState.value
         val currentQuestion = currentState.questions[currentState.currentQuestionIndex]
         val isCorrect = currentQuestion.correctAnswer.equals(answer.trim(), ignoreCase = true)
+        val newScore = if (isCorrect) currentState.score + 1 else currentState.score
+        val progress = if (currentState.questions.isNotEmpty()) {
+            newScore.toFloat() / currentState.questions.size
+        } else {
+            0f
+        }
 
         _uiState.value = currentState.copy(
             isAnswerSubmitted = true,
             isAnswerCorrect = isCorrect,
-            score = if (isCorrect) currentState.score + 1 else currentState.score
+            score = newScore,
+            progress = progress
         )
     }
 
@@ -65,7 +72,8 @@ data class PunctuationUiState(
     val currentQuestionIndex: Int = 0,
     val isAnswerSubmitted: Boolean = false,
     val isAnswerCorrect: Boolean = false,
-    val score: Int = 0
+    val score: Int = 0,
+    val progress: Float = 0f
 )
 
 sealed class NavigationEvent {


### PR DESCRIPTION
This commit modifies the punctuation practice feature to update the progress bar only when a user answers a question correctly.

Previously, the progress was tied to the question index, advancing when the user moved to the next question. This change updates the `PunctuationViewModel` to calculate progress based on the number of correct answers. The `PunctuationPracticeScreen` is updated to display this new progress value using a `LinearProgressIndicator`.