### PR TITLE
Add Unit Tests for Repositories and ViewModels

### DIFF
--- a/app/src/test/java/com/example/readingfoundations/data/PhonemeRepositoryTest.kt
+++ b/app/src/test/java/com/example/readingfoundations/data/PhonemeRepositoryTest.kt
@@ -1,0 +1,40 @@
+package com.example.readingfoundations.data
+
+import com.example.readingfoundations.data.local.PhonemeDao
+import com.example.readingfoundations.data.models.Phoneme
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+
+class PhonemeRepositoryTest {
+
+    @Mock
+    private lateinit var phonemeDao: PhonemeDao
+
+    private lateinit var phonemeRepository: PhonemeRepositoryImpl
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+        phonemeRepository = PhonemeRepositoryImpl(phonemeDao)
+    }
+
+    @Test
+    fun `getAllPhonemes returns flow from dao`() = runTest {
+        val phonemes = listOf(
+            Phoneme(id = 1, grapheme = "a", sound = "a", ttsText = "a", exampleWord = "apple", category = "vowel", level = 1),
+            Phoneme(id = 2, grapheme = "b", sound = "b", ttsText = "b", exampleWord = "ball", category = "consonant", level = 1)
+        )
+        `when`(phonemeDao.getAllPhonemes()).thenReturn(flowOf(phonemes))
+
+        val result = phonemeRepository.getAllPhonemes().first()
+
+        assertEquals(phonemes, result)
+    }
+}

--- a/app/src/test/java/com/example/readingfoundations/data/UnitRepositoryTest.kt
+++ b/app/src/test/java/com/example/readingfoundations/data/UnitRepositoryTest.kt
@@ -1,0 +1,129 @@
+package com.example.readingfoundations.data
+
+import com.example.readingfoundations.data.local.PhonemeDao
+import com.example.readingfoundations.data.local.PunctuationQuestionDao
+import com.example.readingfoundations.data.local.ReadingComprehensionDao
+import com.example.readingfoundations.data.local.SentenceDao
+import com.example.readingfoundations.data.local.UserProgressDao
+import com.example.readingfoundations.data.local.WordDao
+import com.example.readingfoundations.data.models.Unit
+import com.example.readingfoundations.data.models.UserProgress
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+
+class UnitRepositoryTest {
+
+    @Mock
+    private lateinit var userProgressDao: UserProgressDao
+
+    @Mock
+    private lateinit var phonemeDao: PhonemeDao
+
+    @Mock
+    private lateinit var wordDao: WordDao
+
+    @Mock
+    private lateinit var sentenceDao: SentenceDao
+
+    @Mock
+    private lateinit var punctuationQuestionDao: PunctuationQuestionDao
+
+    @Mock
+    private lateinit var readingComprehensionDao: ReadingComprehensionDao
+
+    private lateinit var unitRepository: UnitRepositoryImpl
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+        unitRepository = UnitRepositoryImpl(
+            userProgressDao,
+            phonemeDao,
+            wordDao,
+            sentenceDao,
+            punctuationQuestionDao,
+            readingComprehensionDao
+        )
+    }
+
+    @Test
+    fun `getUnits returns correct units based on max levels`() = runTest {
+        // Mock data
+        val userProgress = UserProgress()
+        `when`(userProgressDao.getUserProgress()).thenReturn(flowOf(userProgress))
+        `when`(phonemeDao.getHighestLevel()).thenReturn(flowOf(2)) // 1 unit
+        `when`(wordDao.getHighestDifficulty()).thenReturn(flowOf(0))
+        `when`(sentenceDao.getHighestDifficulty()).thenReturn(flowOf(0))
+        `when`(punctuationQuestionDao.getHighestLevel()).thenReturn(flowOf(0))
+        `when`(readingComprehensionDao.getHighestLevel()).thenReturn(flowOf(0))
+
+        val units = unitRepository.getUnits().first()
+
+        assertEquals(1, units.size)
+        val unit = units[0]
+        assertEquals(1, unit.id)
+        assertEquals(2, unit.levels.size) // 2 phonetics levels
+        assertEquals(Subjects.PHONETICS, unit.levels[0].subject)
+        assertEquals(1, unit.levels[0].levelNumber)
+        assertEquals(Subjects.PHONETICS, unit.levels[1].subject)
+        assertEquals(2, unit.levels[1].levelNumber)
+    }
+
+    @Test
+    fun `getUnits calculates progress correctly`() = runTest {
+        // Mock data
+        val userProgress = UserProgress(
+            completedLevels = mapOf(Subjects.PHONETICS to listOf(1))
+        )
+        `when`(userProgressDao.getUserProgress()).thenReturn(flowOf(userProgress))
+        `when`(phonemeDao.getHighestLevel()).thenReturn(flowOf(2))
+        `when`(wordDao.getHighestDifficulty()).thenReturn(flowOf(0))
+        `when`(sentenceDao.getHighestDifficulty()).thenReturn(flowOf(0))
+        `when`(punctuationQuestionDao.getHighestLevel()).thenReturn(flowOf(0))
+        `when`(readingComprehensionDao.getHighestLevel()).thenReturn(flowOf(0))
+
+        val units = unitRepository.getUnits().first()
+
+        assertEquals(1, units.size)
+        val unit = units[0]
+        assertEquals(0.5f, unit.progress, 0.01f) // 1 completed out of 2 levels
+        assertEquals(true, unit.levels[0].isCompleted)
+        assertEquals(false, unit.levels[1].isCompleted)
+    }
+
+    @Test
+    fun `updateProgress updates user progress correctly`() = runTest {
+        val initialProgress = UserProgress()
+        `when`(userProgressDao.getUserProgress()).thenReturn(flowOf(initialProgress))
+
+        unitRepository.updateProgress(Subjects.PHONETICS, 1)
+
+        val expectedProgress = UserProgress(
+            completedLevels = mapOf(Subjects.PHONETICS to listOf(1))
+        )
+        verify(userProgressDao).updateUserProgress(expectedProgress)
+    }
+
+    @Test
+    fun `updateProgress does not duplicate existing levels`() = runTest {
+        val initialProgress = UserProgress(
+            completedLevels = mapOf(Subjects.PHONETICS to listOf(1))
+        )
+        `when`(userProgressDao.getUserProgress()).thenReturn(flowOf(initialProgress))
+
+        unitRepository.updateProgress(Subjects.PHONETICS, 1)
+
+        val expectedProgress = UserProgress(
+            completedLevels = mapOf(Subjects.PHONETICS to listOf(1))
+        )
+        verify(userProgressDao).updateUserProgress(expectedProgress)
+    }
+}

--- a/app/src/test/java/com/example/readingfoundations/ui/screens/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/example/readingfoundations/ui/screens/home/HomeViewModelTest.kt
@@ -1,0 +1,120 @@
+package com.example.readingfoundations.ui.screens.home
+
+import com.example.readingfoundations.data.Subjects
+import com.example.readingfoundations.data.UnitRepository
+import com.example.readingfoundations.data.models.Level
+import com.example.readingfoundations.data.models.Unit
+import com.example.readingfoundations.data.models.UserProgress
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+
+@ExperimentalCoroutinesApi
+class HomeViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Mock
+    private lateinit var unitRepository: UnitRepository
+
+    private lateinit var viewModel: HomeViewModel
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `uiState correctly combines units and progress`() = runTest {
+        val testUnits = listOf(
+            Unit(
+                id = 1,
+                levels = listOf(Level(Subjects.PHONETICS, 1, false)),
+                progress = 0f
+            )
+        )
+        val testProgress = UserProgress(
+            completedLevels = mapOf(Subjects.PHONETICS to listOf(1))
+        )
+
+        `when`(unitRepository.getUnits()).thenReturn(flowOf(testUnits))
+        `when`(unitRepository.getUserProgress()).thenReturn(flowOf(testProgress))
+
+        viewModel = HomeViewModel(unitRepository)
+
+        // Ensure the StateFlow is collected to trigger the upstream flows
+        // In a real app, the UI collects it. In a test, accessing .value usually gives the initial value
+        // until collection starts or SharingStarted.Eagerly is used.
+        // However, with WhileSubscribed, it waits for a subscriber.
+
+        // We can use a background collection job
+        // Or we can just access it? No, accessing .value doesn't start collection for WhileSubscribed.
+
+        // Let's use turbine or a simple background collection
+
+        // Actually, stateIn with WhileSubscribed(5000) will keep the value cached for 5s after subscription ends.
+        // But it needs a subscription to start.
+
+        // Wait, I see other tests using stateIn often require a collector.
+
+        // Let's try collecting it in a background job
+        val job = launch {
+            viewModel.uiState.collect {}
+        }
+
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertEquals(testUnits, state.units)
+        assertEquals(testProgress, state.userProgress)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `uiState handles null user progress`() = runTest {
+        val testUnits = listOf(
+            Unit(
+                id = 1,
+                levels = listOf(Level(Subjects.PHONETICS, 1, false)),
+                progress = 0f
+            )
+        )
+
+        `when`(unitRepository.getUnits()).thenReturn(flowOf(testUnits))
+        `when`(unitRepository.getUserProgress()).thenReturn(flowOf(null))
+
+        viewModel = HomeViewModel(unitRepository)
+
+        val job = launch {
+            viewModel.uiState.collect {}
+        }
+
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertEquals(testUnits, state.units)
+        assertEquals(UserProgress(), state.userProgress)
+
+        job.cancel()
+    }
+}

--- a/app/src/test/java/com/example/readingfoundations/ui/screens/phonetics/PhoneticsViewModelTest.kt
+++ b/app/src/test/java/com/example/readingfoundations/ui/screens/phonetics/PhoneticsViewModelTest.kt
@@ -1,0 +1,165 @@
+package com.example.readingfoundations.ui.screens.phonetics
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import com.example.readingfoundations.data.PhonemeRepository
+import com.example.readingfoundations.data.Subjects
+import com.example.readingfoundations.data.UnitRepository
+import com.example.readingfoundations.data.models.Phoneme
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+
+@ExperimentalCoroutinesApi
+class PhoneticsViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Mock
+    private lateinit var unitRepository: UnitRepository
+
+    @Mock
+    private lateinit var phonemeRepository: PhonemeRepository
+
+    private lateinit var viewModel: PhoneticsViewModel
+
+    private val testPhonemes = listOf(
+        Phoneme(id = 1, grapheme = "a", sound = "a", ttsText = "a", exampleWord = "apple", category = "vowel", level = 1),
+        Phoneme(id = 2, grapheme = "b", sound = "b", ttsText = "b", exampleWord = "ball", category = "consonant", level = 1),
+        Phoneme(id = 3, grapheme = "c", sound = "c", ttsText = "c", exampleWord = "cat", category = "consonant", level = 1),
+        Phoneme(id = 4, grapheme = "d", sound = "d", ttsText = "d", exampleWord = "dog", category = "consonant", level = 1)
+    )
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+        Dispatchers.setMain(testDispatcher)
+
+        `when`(phonemeRepository.getAllPhonemes()).thenReturn(flowOf(testPhonemes))
+
+        val savedStateHandle = SavedStateHandle().apply {
+            set("level", 1)
+        }
+
+        viewModel = PhoneticsViewModel(unitRepository, phonemeRepository, savedStateHandle)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initial state loads phonemes correctly`() = runTest {
+        // Wait for the initialization coroutine to complete
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.isLoading)
+        assertEquals(testPhonemes, state.phonemes)
+        assertEquals(1, state.currentLevel)
+    }
+
+    @Test
+    fun `startPractice initializes quiz correctly`() = runTest {
+        advanceUntilIdle()
+        viewModel.startPractice()
+
+        val state = viewModel.uiState.value
+        assertTrue(state.isPracticeMode)
+        assertNotNull(state.quizState)
+        assertEquals(0, state.quizState?.currentQuestionIndex)
+        assertEquals(0, state.quizState?.score)
+        assertEquals(4, state.quizState?.questions?.size)
+    }
+
+    @Test
+    fun `checkAnswer updates score correctly for correct answer`() = runTest {
+        advanceUntilIdle()
+        viewModel.startPractice()
+
+        val state = viewModel.uiState.value
+        val target = state.quizState!!.targetPhoneme!!
+
+        viewModel.checkAnswer(target)
+
+        val newState = viewModel.uiState.value
+        assertEquals(true, newState.quizState!!.isAnswerCorrect)
+        assertEquals(1, newState.quizState!!.score)
+        assertEquals(target, newState.quizState!!.selectedOption)
+    }
+
+    @Test
+    fun `checkAnswer updates state correctly for incorrect answer`() = runTest {
+        advanceUntilIdle()
+        viewModel.startPractice()
+
+        val state = viewModel.uiState.value
+        val target = state.quizState!!.targetPhoneme!!
+        val incorrectOption = testPhonemes.first { it.id != target.id }
+
+        viewModel.checkAnswer(incorrectOption)
+
+        val newState = viewModel.uiState.value
+        assertEquals(false, newState.quizState!!.isAnswerCorrect)
+        assertEquals(0, newState.quizState!!.score)
+        assertEquals(incorrectOption, newState.quizState!!.selectedOption)
+    }
+
+    @Test
+    fun `nextQuestion advances to next question`() = runTest {
+        advanceUntilIdle()
+        viewModel.startPractice()
+
+        val initialState = viewModel.uiState.value
+        val initialIndex = initialState.quizState!!.currentQuestionIndex
+
+        viewModel.nextQuestion()
+
+        val newState = viewModel.uiState.value
+        assertEquals(initialIndex + 1, newState.quizState!!.currentQuestionIndex)
+    }
+
+    @Test
+    fun `completing quiz updates progress and navigates`() = runTest {
+        advanceUntilIdle()
+        viewModel.startPractice()
+
+        // Go through all questions
+        val totalQuestions = testPhonemes.size
+        repeat(totalQuestions - 1) {
+            viewModel.nextQuestion()
+        }
+
+        // On the last question, calling nextQuestion should finish the quiz
+        viewModel.nextQuestion()
+        advanceUntilIdle()
+
+        verify(unitRepository).updateProgress(Subjects.PHONETICS, 1)
+
+        viewModel.navigationEvent.test {
+            val event = awaitItem()
+            assertTrue(event is NavigationEvent.LevelComplete)
+            val levelCompleteEvent = event as NavigationEvent.LevelComplete
+            assertEquals(1, levelCompleteEvent.level)
+            assertEquals(totalQuestions, levelCompleteEvent.totalQuestions)
+        }
+    }
+}


### PR DESCRIPTION
Added comprehensive unit tests for `UnitRepository`, `PhonemeRepository`, `PhoneticsViewModel`, and `HomeViewModel`. These tests cover critical business logic such as unit generation, progress tracking, quiz state management, and UI state aggregation. This ensures the reliability of core features and provides a safeguard against regressions in future development.

---
*PR created automatically by Jules for task [8214045294686852321](https://jules.google.com/task/8214045294686852321) started by @ColbyCabrera*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded unit test coverage across repositories and UI screens.
  * Added repository tests validating phoneme retrieval, unit assembly, and progress update logic.
  * Added HomeViewModel tests for combined units and progress states (including null progress).
  * Added PhoneticsViewModel tests covering quiz lifecycle, scoring, navigation, and progress updates.
  * Minor import cleanup in punctuation-related tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->